### PR TITLE
Have the -a flag request a review instead of assigning the pull request

### DIFF
--- a/lib/hub/github_api.rb
+++ b/lib/hub/github_api.rb
@@ -175,11 +175,11 @@ module Hub
 
       if options[:assignee]
           params = {
-              :assignee => options[:assignee]
+              :reviewers => options[:assignee].split(',')
           }
 
-          url = res.data['_links']['issue']['href']
-          res = patch url, params
+          url = "#{res.data['_links']['self']['href']}/requested_reviewers"
+          res = post url, params
 
           res.error! unless res.success?
       end


### PR DESCRIPTION
We've been using Github's reviewer feature since it was released, and the `-a` flag was really helpful when you knew who you wanted a review from. This changes it to request a review from one or more engineers instead of setting the assignee. I kept it as the `-a` option because it's familiar and because `-r` is already taken. I'm not even sure how many gusto devs still even use hub to create pull requests, but I miss this little convenience, especially when working on a project where I'm regularly requesting reviews from the same person.

API documentation on creating review requests:
https://developer.github.com/v3/pulls/review_requests/#create-a-review-request